### PR TITLE
Message v RequestException

### DIFF
--- a/src/DataApi/Request.php
+++ b/src/DataApi/Request.php
@@ -84,7 +84,12 @@ class Request
 			return $this->client->send($request);
 		}
 		catch (RequestException $ex) {
-			$message = $this->getErrorMessage($ex->getResponse());
+			$response = $ex->getResponse();
+			if ($response !== NULL) {
+				$message = $this->getErrorMessage($response);
+			} else {
+				$message = $ex->getMessage();
+			}
 			throw new RequestFailedException($message, $ex->getCode(), $ex);
 		}
 	}


### PR DESCRIPTION
V případě chyby je občas response v RequestException prázdná a tak vyhozená RequestFailedException nemá žádný text. 
Pokud to tedy není záměr.
